### PR TITLE
Copy STDOUT to reports instead of capturing it

### DIFF
--- a/lib/ci/reporter/duplex.rb
+++ b/lib/ci/reporter/duplex.rb
@@ -1,0 +1,27 @@
+module CI
+  module Reporter
+    class Duplex
+      def initialize(primary, secondary)
+        @primary = primary
+        @secondary = secondary
+      end
+
+      def __primary__
+        @primary
+      end
+
+      def __secondary__
+        @secondary
+      end
+
+      def respond_to_missing?(name, include_all = true)
+        super || @primary.respond_to?(name, include_all)
+      end
+
+      def method_missing(name, *args)
+        @secondary.public_send(name, *args)
+        @primary.public_send(name, *args)
+      end
+    end
+  end
+end

--- a/lib/ci/reporter/output_capture.rb
+++ b/lib/ci/reporter/output_capture.rb
@@ -1,6 +1,8 @@
 require 'delegate'
 require 'stringio'
 
+require 'ci/reporter/duplex'
+
 module CI
   module Reporter
     # Captures $stdout or $stderr in order report it in the XML file.
@@ -18,7 +20,7 @@ module CI
 
       # Start capturing IO.
       def start
-        @assign_block.call(@captured_io)
+        @assign_block.call(Duplex.new(@captured_io, @original_io))
       end
 
       # Finalize the capture and reset to the original IO object.


### PR DESCRIPTION
This will make things logged during tests show up in the same Jenkins UI and things logged between tests.