### PR TITLE
Pass through method calls & `repond_to?` to the original output

### DIFF
--- a/lib/ci/reporter/duplex.rb
+++ b/lib/ci/reporter/duplex.rb
@@ -11,8 +11,10 @@ module CI
       end
 
       def method_missing(name, *args)
+        if @captured.respond_to?(name)
+          @captured.public_send(name, *args)
+        end
         @original.public_send(name, *args)
-        @captured.public_send(name, *args)
       end
     end
   end

--- a/lib/ci/reporter/duplex.rb
+++ b/lib/ci/reporter/duplex.rb
@@ -7,7 +7,7 @@ module CI
       end
 
       def respond_to_missing?(name, include_all = true)
-        super || @captured.respond_to?(name, include_all)
+        super || @original.respond_to?(name, include_all)
       end
 
       def method_missing(name, *args)

--- a/lib/ci/reporter/duplex.rb
+++ b/lib/ci/reporter/duplex.rb
@@ -6,14 +6,6 @@ module CI
         @secondary = secondary
       end
 
-      def __primary__
-        @primary
-      end
-
-      def __secondary__
-        @secondary
-      end
-
       def respond_to_missing?(name, include_all = true)
         super || @primary.respond_to?(name, include_all)
       end

--- a/lib/ci/reporter/duplex.rb
+++ b/lib/ci/reporter/duplex.rb
@@ -1,18 +1,18 @@
 module CI
   module Reporter
     class Duplex
-      def initialize(primary, secondary)
-        @primary = primary
-        @secondary = secondary
+      def initialize(captured, original)
+        @captured = captured
+        @original = original
       end
 
       def respond_to_missing?(name, include_all = true)
-        super || @primary.respond_to?(name, include_all)
+        super || @captured.respond_to?(name, include_all)
       end
 
       def method_missing(name, *args)
-        @secondary.public_send(name, *args)
-        @primary.public_send(name, *args)
+        @original.public_send(name, *args)
+        @captured.public_send(name, *args)
       end
     end
   end


### PR DESCRIPTION
So `Duplex` sends methods to both the capturing output and the original output, nice. But it doesn't pass through calls to `respond_to?`, so any consumers who expect a particular method to be available (like `path` for a file) will quickly uncover the deception and loudly decry it.

I changed it so `Duplex` only responds to things the original output would, and also made the method calls optional for the captured output (like for `path`, which a `StringIO` object won't have).